### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Amazon DynamoDB output plugin for Fluent event collector
+# Amazon DynamoDB output plugin for [Fluentd](http://fluentd.org) event collector
 
 ##Installation
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
