### PR TITLE
Fix gem dependency

### DIFF
--- a/fluent-plugin-dynamodb.gemspec
+++ b/fluent-plugin-dynamodb.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_dependency "fluentd", "~> 0.10.0"
+  gem.add_dependency "fluentd", [">= 0.10.0", "< 2"]
   gem.add_dependency "aws-sdk-v1", ">= 1.5.2"
   gem.add_dependency "uuidtools", "~> 2.1.0"
   gem.add_development_dependency "rake", ">= 0.9.2"

--- a/fluent-plugin-dynamodb.gemspec
+++ b/fluent-plugin-dynamodb.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency "fluentd", "~> 0.10.0"
-  gem.add_dependency "aws-sdk", ">= 1.5.2"
+  gem.add_dependency "aws-sdk-v1", ">= 1.5.2"
   gem.add_dependency "uuidtools", "~> 2.1.0"
   gem.add_development_dependency "rake", ">= 0.9.2"
+  gem.add_development_dependency "test-unit", ">= 3.1.0"
 end

--- a/lib/fluent/plugin/out_dynamodb.rb
+++ b/lib/fluent/plugin/out_dynamodb.rb
@@ -12,7 +12,7 @@ class DynamoDBOutput < Fluent::BufferedOutput
 
   def initialize
     super
-    require 'aws-sdk'
+    require 'aws-sdk-v1'
     require 'msgpack'
     require 'time'
     require 'uuidtools'


### PR DESCRIPTION
Ruby 2.2 does not provide minitest with test-unit compatible API.

And `aws-sdk >= 1.5` in gemspec leads to install aws-sdk v2 gem.
It seems that this repository does not have compatibility for aws-sdk-v2.
Thus, I fixed dependency for aws-sdk-**v1**.