### PR TITLE
Support secret parameters

### DIFF
--- a/lib/fluent/plugin/out_dynamodb.rb
+++ b/lib/fluent/plugin/out_dynamodb.rb
@@ -18,8 +18,8 @@ class DynamoDBOutput < Fluent::BufferedOutput
     require 'uuidtools'
   end
 
-  config_param :aws_key_id, :string, :default => nil
-  config_param :aws_sec_key, :string, :default => nil
+  config_param :aws_key_id, :string, :default => nil, :secret => true
+  config_param :aws_sec_key, :string, :default => nil, :secret => true
   config_param :proxy_uri, :string, :default => nil
   config_param :dynamo_db_table, :string
   config_param :dynamo_db_endpoint, :string, :default => nil


### PR DESCRIPTION
Fluentd 0.12.13 or later supports secret parameter feature.
This feature works as below:

```log
  <match dynamodb.**>
    type dynamodb
    aws_key_id xxxxxx
    aws_sec_key xxxxxx
    proxy_uri http://user:password@192.168.0.250:3128/
    dynamo_db_endpoint dynamodb.ap-northeast-1.amazonaws.com
    dynamo_db_table access_log
  </match>
</ROOT>
```

If you use older fluentd, `:secret => true` in config_param will be simply ignored.