### PR TITLE
Use aws-sdk v2

### DIFF
--- a/fluent-plugin-dynamodb.gemspec
+++ b/fluent-plugin-dynamodb.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency "fluentd", [">= 0.10.0", "< 2"]
-  gem.add_dependency "aws-sdk-v1", ">= 1.5.2"
+  gem.add_dependency "aws-sdk", [">= 2.3.22", "< 3"]
   gem.add_dependency "uuidtools", "~> 2.1.0"
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "test-unit", ">= 3.1.0"


### PR DESCRIPTION
I've tried to use aws-sdk v2 instead of v1.
I've confirmed that this plugin can create records into DynamoDB with basic usage.
With the following config(without sensitive information):

```aconf
<source>
  @type forward
</source>
<match dynamodb.**>
  @type dynamodb
  aws_key_id AWS_KEY_ID
  aws_sec_key AWS_SEC_KEY
  detach_process 6
  dynamo_db_region us-east-2
  dynamo_db_endpoint https://dynamodb.us-east-2.amazonaws.com
  dynamo_db_table fluent_test
</match>
```

This PR also works with your configuration?

Thanks in advance.