### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,17 +80,19 @@ By the way, you can write scan-filter with AWS SDK like [this](https://gist.gith
 
 ###multiprocessing
 
-If you need high throughput and if you have much provisioned throughput and abudant buffer, you can setup multiprocessing. fluent-plugin-dynamo inherits **DetachMultiProcessMixin**, so you can launch 6 processes as follows.
+If you need high throughput and if you have much provisioned throughput and abudant buffer, you can setup multiprocessing. fluent-plugin-dynamodb uses **multi workers**, so you can launch 6 workers as follows.
 
     <match dynamodb.**>
       @type dynamodb
       aws_key_id AWS_ACCESS_KEY
       aws_sec_key AWS_SECRET_ACCESS_KEY
       proxy_uri http://user:password@192.168.0.250:3128/
-      detach_process 6
       dynamo_db_endpoint dynamodb.ap-northeast-1.amazonaws.com
       dynamo_db_table access_log
     </match>
+    <system>
+      workers 6
+    </system>
 
 ###multi-region redundancy
 

--- a/fluent-plugin-dynamodb.gemspec
+++ b/fluent-plugin-dynamodb.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_dependency "fluentd", [">= 0.10.0", "< 2"]
+  gem.add_dependency "fluentd", [">= 0.14.15", "< 2"]
   gem.add_dependency "aws-sdk", [">= 2.3.22", "< 3"]
   gem.add_dependency "uuidtools", "~> 2.1.0"
   gem.add_development_dependency "rake", ">= 0.9.2"

--- a/lib/fluent/plugin/out_dynamodb.rb
+++ b/lib/fluent/plugin/out_dynamodb.rb
@@ -15,17 +15,8 @@ class DynamoDBOutput < Fluent::Plugin::Output
 
   DEFAULT_BUFFER_TYPE = "memory"
 
-  # To support log_level option implemented by Fluentd v0.10.43
-  unless method_defined?(:log)
-    define_method("log") { $log }
-  end
-
   BATCHWRITE_ITEM_LIMIT = 25
   BATCHWRITE_CONTENT_SIZE_LIMIT = 1024*1024
-
-  def initialize
-    super
-  end
 
   config_param :aws_key_id, :string, :default => nil, :secret => true
   config_param :aws_sec_key, :string, :default => nil, :secret => true

--- a/lib/fluent/plugin/out_dynamodb.rb
+++ b/lib/fluent/plugin/out_dynamodb.rb
@@ -32,6 +32,7 @@ class DynamoDBOutput < Fluent::Plugin::Output
   end
 
   def configure(conf)
+    compat_parameters_convert(conf, :buffer)
     super
 
     @timef = Fluent::TimeFormatter.new(@time_format, @localtime)

--- a/lib/fluent/plugin/out_dynamodb.rb
+++ b/lib/fluent/plugin/out_dynamodb.rb
@@ -29,7 +29,6 @@ class DynamoDBOutput < Fluent::Plugin::Output
 
   config_section :buffer do
     config_set_default :@type, DEFAULT_BUFFER_TYPE
-    config_set_default :chunk_keys, ['tag']
   end
 
   def configure(conf)

--- a/lib/fluent/plugin/out_dynamodb.rb
+++ b/lib/fluent/plugin/out_dynamodb.rb
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
 require 'fluent/plugin/output'
+require 'aws-sdk'
+require 'msgpack'
+require 'time'
+require 'uuidtools'
+
 module Fluent::Plugin
 
 
@@ -20,10 +25,6 @@ class DynamoDBOutput < Fluent::Plugin::Output
 
   def initialize
     super
-    require 'aws-sdk'
-    require 'msgpack'
-    require 'time'
-    require 'uuidtools'
   end
 
   config_param :aws_key_id, :string, :default => nil, :secret => true


### PR DESCRIPTION
I've tried to migrate to use Fluentd v0.14 Output Plugin API in this plugin.
How about use v0.14 API in this plugin?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks,