### PR TITLE
Use aws-sdk-v3 dynamodb specific gem

### DIFF
--- a/fluent-plugin-dynamodb.gemspec
+++ b/fluent-plugin-dynamodb.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency "fluentd", [">= 0.14.15", "< 2"]
-  gem.add_dependency "aws-sdk", [">= 2.3.22", "< 3"]
+  gem.add_dependency "aws-sdk-dynamodb", [">= 1.0.0", "< 2"]
   gem.add_dependency "uuidtools", "~> 2.1.0"
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "test-unit", ">= 3.1.0"

--- a/lib/fluent/plugin/out_dynamodb.rb
+++ b/lib/fluent/plugin/out_dynamodb.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 require 'fluent/plugin/output'
-require 'aws-sdk'
+require 'aws-sdk-dynamodb'
 require 'msgpack'
 require 'time'
 require 'uuidtools'


### PR DESCRIPTION
aws-sdk-v3 and service specific gems are released.

For DynamoDB:
https://rubygems.org/gems/aws-sdk-dynamodb

Then, we can migrate to use aws-sdk v3 dynamodb specific gem.

ref: https://aws.amazon.com/jp/blogs/developer/upgrading-from-version-2-to-version-3-of-the-aws-sdk-for-ruby-2/